### PR TITLE
Release/0.3.0

### DIFF
--- a/annotations2triannon.gemspec
+++ b/annotations2triannon.gemspec
@@ -30,9 +30,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'rest-client'
   s.add_dependency 'rest-client-components'
   s.add_dependency 'rack-cache'
-  # Concurrent HTTP requests
-  s.add_dependency 'parallel'
-  s.add_dependency 'ruby-progressbar'
   # dalli is a memcached ruby client
   s.add_dependency 'dalli'
   # Use pry for console and debug config

--- a/annotations2triannon.gemspec
+++ b/annotations2triannon.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = 'annotations2triannon'
-  s.version     = '0.2.2'
+  s.version     = '0.3.0'
   s.licenses    = ['Apache-2.0']
   s.platform    = Gem::Platform::RUBY
 

--- a/bin/dms.rb
+++ b/bin/dms.rb
@@ -178,8 +178,7 @@ text_annotations.each_pair do |m,anno_lists|
   anno_lists.each_pair do |anno_list_uri, anno_list|
     puts "Posting:\t#{anno_list_uri}\t=> #{anno_list.length}"
     anno_tracking[m][anno_list_uri] = []
-    # Allow Parallel to automatically determine the optimal concurrency model.
-    Parallel.each(anno_list, :progress => 'Annotations: ') do |oa|
+    anno_list.each do |oa|
       response = tc.post_annotation(oa.to_jsonld_oa)
       # parse the response into an RDF::Graph
       graph = tc.response2graph(response)
@@ -191,8 +190,11 @@ text_annotations.each_pair do |m,anno_lists|
           chars: oa.body_contentChars.first
         }
         anno_tracking[m][anno_list_uri].push(anno_data)
+      else
+        CONFIG.logger.error("FAILURE to POST #{oa.id}")
       end
     end
+    anno_tracking_save(anno_tracking)
   end
 end
 anno_tracking_save(anno_tracking)

--- a/lib/annotations2triannon/open_annotation.rb
+++ b/lib/annotations2triannon/open_annotation.rb
@@ -27,10 +27,7 @@ module Annotations2triannon
       else
         @graph = graph
         raise ArgumentError, 'graph must be an open annotation' unless is_annotation?
-        if id.nil?
-          @id = get_id
-        else
-        end
+        id.nil? ? @id = get_id : @id = id
       end
     end
 

--- a/lib/requires.rb
+++ b/lib/requires.rb
@@ -39,9 +39,6 @@ require 'addressable/uri'
 require 'json'
 require 'uuid'
 
-require 'ruby-progressbar'
-require 'parallel'
-
 require 'linkeddata'
 require_relative 'rdf/vocab/sc.rb'
 


### PR DESCRIPTION
This release backs out threading for triannon POSTS in the DMS ETL, only because it fails to save the anno URIs in the tracking log file.  This is required for repeating the ETL.  There may be alternative solutions for the tracking problem with threading, but that will be left for another release.
